### PR TITLE
Prevent error when directory run without arguments

### DIFF
--- a/share/appliance_cli/src/utils.py
+++ b/share/appliance_cli/src/utils.py
@@ -62,7 +62,7 @@ def read_config(config_file_path):
 
 def in_sandbox():
     # We're in the sandbox if the program was started with the 'sandbox' arg.
-    return sys.argv[1] == 'sandbox'
+    return len(sys.argv) > 1 and sys.argv[1] == 'sandbox'
 
 
 def is_valid_ssh_public_key(string):


### PR DESCRIPTION
Since we now call `utils.in_sandbox` at the top level within
`import_export.add_commands`, we now also need to handle the case where
`sys.argv` does not contain anything at index 1 - previously running
just `directory` without arguments was causing an IndexError due to not
checking this.