### PR TITLE
Fix/group member errors

### DIFF
--- a/directory/cli/src/group.py
+++ b/directory/cli/src/group.py
@@ -63,7 +63,7 @@ def add_commands(directory):
     # TODO duplication
     @group.command(name='add-member', help='Add user(s) to a group')
     @click.argument('group_name')
-    @click.argument('users', nargs=-1)
+    @click.argument('users', nargs=-1, required=True)
     def add_member(group_name, users):
         _validate_blacklist_groups(group_name, users)
         user_options = ['--users={}'.format(user) for user in users]
@@ -77,7 +77,7 @@ def add_commands(directory):
 
     @group.command(name='remove-member', help='Remove user(s) from a group')
     @click.argument('group_name')
-    @click.argument('users', nargs=-1)
+    @click.argument('users', nargs=-1, required=True)
     def remove_member(group_name, users):
         _validate_blacklist_groups(group_name, users)
         user_options = ['--users={}'.format(user) for user in users]

--- a/directory/cli/src/group.py
+++ b/directory/cli/src/group.py
@@ -69,7 +69,11 @@ def add_commands(directory):
         user_options = ['--users={}'.format(user) for user in users]
         ipa_command = 'group-add-member'
         args = [group_name] + user_options
-        ipa_utils.ipa_run(ipa_command, args, error_in_stdout=True)
+        try:
+            ipa_utils.ipa_run(ipa_command, args, error_in_stdout=True)
+        except IpaRunError:
+            error = "Group add member failed"
+            raise click.ClickException(error)
 
     @group.command(name='remove-member', help='Remove user(s) from a group')
     @click.argument('group_name')
@@ -79,7 +83,11 @@ def add_commands(directory):
         user_options = ['--users={}'.format(user) for user in users]
         ipa_command = 'group-remove-member'
         args = [group_name] + user_options
-        ipa_utils.ipa_run(ipa_command, args, error_in_stdout=True)
+        try:
+            ipa_utils.ipa_run(ipa_command, args, error_in_stdout=True)
+        except IpaRunError:
+            error = "Group remove member failed"
+            raise click.ClickException(error)
 
     wrapper_commands = [
         ipa_wrapper_command.create(

--- a/directory/cli/src/host.py
+++ b/directory/cli/src/host.py
@@ -184,7 +184,7 @@ def _modify_ip(argument, new_ip):
         args = [domain_name, host_label , '--a-rec='+new_ip]
         ipa_utils.ipa_run('dnsrecord-mod', args, record=True)
     else:
-        error = "The host " + argument + " does not exist"
+        error = "Host " + argument + " not found"
         raise click.ClickException(error)
 
 def _transform_delete_options(argument, options):

--- a/directory/cli/src/hostgroup.py
+++ b/directory/cli/src/hostgroup.py
@@ -59,7 +59,6 @@ def add_commands(directory):
 
     @hostgroup.command(name='add-member', help='Add host(s) to a host group')
     @click.argument('hostgroup_name')
-    # make this take at least 1
     @click.argument('hosts', nargs=-1, required=True)
     def add_member(hostgroup_name, hosts):
         _validate_blacklist_hostgroups(hostgroup_name, hosts)

--- a/directory/cli/src/hostgroup.py
+++ b/directory/cli/src/hostgroup.py
@@ -65,7 +65,11 @@ def add_commands(directory):
         host_options = ['--hosts={}'.format(host) for host in hosts]
         ipa_command = 'hostgroup-add-member'
         args = [hostgroup_name] + host_options
-        ipa_utils.ipa_run(ipa_command, args, error_in_stdout=True)
+        try:
+            ipa_utils.ipa_run(ipa_command, args, error_in_stdout=True)
+        except IpaRunError:
+            error = "Host group add member failed"
+            raise click.ClickException(error)
 
     @hostgroup.command(name='remove-member', help='Remove host(s) from a host group')
     @click.argument('hostgroup_name')
@@ -75,7 +79,11 @@ def add_commands(directory):
         host_options = ['--hosts={}'.format(host) for host in hosts]
         ipa_command = 'hostgroup-remove-member'
         args = [hostgroup_name] + host_options
-        ipa_utils.ipa_run(ipa_command, args, error_in_stdout=True)
+        try:
+            ipa_utils.ipa_run(ipa_command, args, error_in_stdout=True)
+        except IpaRunError:
+            error = "Host group remove member failed"
+            raise click.ClickException(error)
 
 
     wrapper_commands = [

--- a/directory/cli/src/hostgroup.py
+++ b/directory/cli/src/hostgroup.py
@@ -9,110 +9,110 @@ from exceptions import IpaRunError
 from option_transformer import OptionTransformer
 
 HOSTGROUP_LIST_FIELD_CONFIGS = OrderedDict([
-	('Host-group', field_with_same_name),
-	('Description', field_with_same_name),
+    ('Host-group', field_with_same_name),
+    ('Description', field_with_same_name),
 ])
 
 HOSTGROUP_SHOW_FIELD_CONFIGS = HOSTGROUP_LIST_FIELD_CONFIGS.copy()
 HOSTGROUP_SHOW_FIELD_CONFIGS.update([
-	('Member hosts', field_with_same_name),
+    ('Member hosts', field_with_same_name),
 ])
 
 HOSTGROUP_OPTIONS = {
-	'--desc':{'help': 'Host group description'}
+    '--desc':{'help': 'Host group description'}
 }
 
 HOSTGROUP_BLACKLIST = ['adminnode', 'ipaservers']
 
 def add_commands(directory):
 
-	@directory.group(help='Manage host groups')
-	def hostgroup():
-		pass
+    @directory.group(help='Manage host groups')
+    def hostgroup():
+        pass
 
-	@hostgroup.command(help='List all host groups')
-	def list():
-		list_command.do(
-			ipa_find_command='hostgroup-find',
-			field_configs=HOSTGROUP_LIST_FIELD_CONFIGS,
-			sort_key='Host-group',
-			blacklist_key='Host-group',
-			blacklist_val_array=HOSTGROUP_BLACKLIST,
-		)
+    @hostgroup.command(help='List all host groups')
+    def list():
+        list_command.do(
+            ipa_find_command='hostgroup-find',
+            field_configs=HOSTGROUP_LIST_FIELD_CONFIGS,
+            sort_key='Host-group',
+            blacklist_key='Host-group',
+            blacklist_val_array=HOSTGROUP_BLACKLIST,
+        )
 	
-	@hostgroup.command(help='Show detailed information on one host group')
-	@click.argument('hostgroup_name')
-	def show(hostgroup_name):
-		_validate_blacklist_hostgroups(hostgroup_name)
-		hostgroup_find_args = ['--hostgroup-name={}'.format(hostgroup_name)]
-		try:
-			list_command.do(
-				ipa_find_command='hostgroup-find',
-				ipa_find_args=hostgroup_find_args,
-				field_configs=HOSTGROUP_SHOW_FIELD_CONFIGS,
-				display=list_command.list_displayer
-			)
-		except IpaRunError:
-			#no hostgroup by that name found
-			error = '{}: group not found'.format(hostgroup_name)
-			raise click.ClickException(error)
+    @hostgroup.command(help='Show detailed information on one host group')
+    @click.argument('hostgroup_name')
+    def show(hostgroup_name):
+        _validate_blacklist_hostgroups(hostgroup_name)
+        hostgroup_find_args = ['--hostgroup-name={}'.format(hostgroup_name)]
+        try:
+            list_command.do(
+                ipa_find_command='hostgroup-find',
+                ipa_find_args=hostgroup_find_args,
+                field_configs=HOSTGROUP_SHOW_FIELD_CONFIGS,
+                display=list_command.list_displayer
+            )
+        except IpaRunError:
+            #no hostgroup by that name found
+            error = '{}: group not found'.format(hostgroup_name)
+            raise click.ClickException(error)
 
-	@hostgroup.command(name='add-member', help='Add host(s) to a host group')
-	@click.argument('hostgroup_name')
-	@click.argument('hosts', nargs=-1)
-	def add_member(hostgroup_name, hosts):
-		_validate_blacklist_hostgroups(hostgroup_name, hosts)
-		host_options = ['--hosts={}'.format(host) for host in hosts]
-		ipa_command = 'hostgroup-add-member'
-		args = [hostgroup_name] + host_options
-		ipa_utils.ipa_run(ipa_command, args, error_in_stdout=True)
+    @hostgroup.command(name='add-member', help='Add host(s) to a host group')
+    @click.argument('hostgroup_name')
+    @click.argument('hosts', nargs=-1)
+    def add_member(hostgroup_name, hosts):
+        _validate_blacklist_hostgroups(hostgroup_name, hosts)
+        host_options = ['--hosts={}'.format(host) for host in hosts]
+        ipa_command = 'hostgroup-add-member'
+        args = [hostgroup_name] + host_options
+        ipa_utils.ipa_run(ipa_command, args, error_in_stdout=True)
 
-	@hostgroup.command(name='remove-member', help='Remove host(s) from a host group') 
-	@click.argument('hostgroup_name')
-	@click.argument('hosts', nargs=-1)
-	def remove_member(hostgroup_name, hosts):
-		_validate_blacklist_hostgroups(hostgroup_name, hosts)
-		host_options = ['--hosts={}'.format(host) for host in hosts]
-		ipa_command = 'hostgroup-remove-member'
-		args = [hostgroup_name] + host_options
-		ipa_utils.ipa_run(ipa_command, args, error_in_stdout=True)
+    @hostgroup.command(name='remove-member', help='Remove host(s) from a host group')
+    @click.argument('hostgroup_name')
+    @click.argument('hosts', nargs=-1)
+    def remove_member(hostgroup_name, hosts):
+        _validate_blacklist_hostgroups(hostgroup_name, hosts)
+        host_options = ['--hosts={}'.format(host) for host in hosts]
+        ipa_command = 'hostgroup-remove-member'
+        args = [hostgroup_name] + host_options
+        ipa_utils.ipa_run(ipa_command, args, error_in_stdout=True)
 
 
-	wrapper_commands = [
-		ipa_wrapper_command.create(
-			'create',
-			ipa_command='hostgroup-add',
-			argument_name='name',
-			options=HOSTGROUP_OPTIONS,
-			transform_options_callback=_transform_options,
-			help='Create a new host group',
-		),
-		ipa_wrapper_command.create(
-			'modify',
-			ipa_command='hostgroup-mod',
-			argument_name='name',
-			options=HOSTGROUP_OPTIONS,
-			transform_options_callback=_transform_options,
-			help='Modify an existing host group',
-		),
-		ipa_wrapper_command.create(
-			'delete',
-			ipa_command='hostgroup-del',
-			argument_name='name',
-			options=HOSTGROUP_OPTIONS,
-			transform_options_callback=_transform_options,
-			help='Delete a host group',
-		)
-	]
+    wrapper_commands = [
+        ipa_wrapper_command.create(
+            'create',
+            ipa_command='hostgroup-add',
+            argument_name='name',
+            options=HOSTGROUP_OPTIONS,
+            transform_options_callback=_transform_options,
+            help='Create a new host group',
+        ),
+        ipa_wrapper_command.create(
+            'modify',
+            ipa_command='hostgroup-mod',
+            argument_name='name',
+            options=HOSTGROUP_OPTIONS,
+            transform_options_callback=_transform_options,
+            help='Modify an existing host group',
+        ),
+        ipa_wrapper_command.create(
+            'delete',
+            ipa_command='hostgroup-del',
+            argument_name='name',
+            options=HOSTGROUP_OPTIONS,
+            transform_options_callback=_transform_options,
+            help='Delete a host group',
+        )
+    ]
 
-	for command in wrapper_commands:
-		hostgroup.add_command(command)
+    for command in wrapper_commands:
+        hostgroup.add_command(command)
 
 def _transform_options(argument, options):
-	_validate_blacklist_hostgroups(argument)
-	return options
+    _validate_blacklist_hostgroups(argument)
+    return options
 
 def _validate_blacklist_hostgroups(argument, options={}):
-	if argument in HOSTGROUP_BLACKLIST:
-		error = "The host group " + argument + " is a resricted hostgroup"
-		raise click.ClickException(error)
+    if argument in HOSTGROUP_BLACKLIST:
+        error = "The host group " + argument + " is a resricted hostgroup"
+        raise click.ClickException(error)

--- a/directory/cli/src/hostgroup.py
+++ b/directory/cli/src/hostgroup.py
@@ -59,7 +59,8 @@ def add_commands(directory):
 
     @hostgroup.command(name='add-member', help='Add host(s) to a host group')
     @click.argument('hostgroup_name')
-    @click.argument('hosts', nargs=-1)
+    # make this take at least 1
+    @click.argument('hosts', nargs=-1, required=True)
     def add_member(hostgroup_name, hosts):
         _validate_blacklist_hostgroups(hostgroup_name, hosts)
         host_options = ['--hosts={}'.format(host) for host in hosts]
@@ -73,7 +74,7 @@ def add_commands(directory):
 
     @hostgroup.command(name='remove-member', help='Remove host(s) from a host group')
     @click.argument('hostgroup_name')
-    @click.argument('hosts', nargs=-1)
+    @click.argument('hosts', nargs=-1, required=True)
     def remove_member(hostgroup_name, hosts):
         _validate_blacklist_hostgroups(hostgroup_name, hosts)
         host_options = ['--hosts={}'.format(host) for host in hosts]


### PR DESCRIPTION
Adds informative errors for issues adding/removing members from groups (Fixes #30)
 - (however this is computationally intensive & should be disabled if speed becomes an issue)
Makes a 2nd argument for the add/remove members required so that an error is properly generated if left out (Fixes #29) 
Re-indents `Hostgroup`
