### PR TITLE
Reduce time taken for `user show`

### DIFF
--- a/directory/cli/src/ipa_utils.py
+++ b/directory/cli/src/ipa_utils.py
@@ -69,12 +69,13 @@ def _strip_all(strings):
     return [string.strip() for string in strings]
 
 
-def ipa_run(ipa_command, args=[], error_in_stdout=False, record=True):
+def ipa_run(ipa_command, args=[], error_allowed=None, error_in_stdout=False, record=True):
     command = ['ipa', '--no-prompt'] + [ipa_command] + args
 
     try:
         result = appliance_cli.utils.run(command)
-        result.check_returncode()
+        if (error_allowed == None or not error_allowed in result.stdout):
+            result.check_returncode()
     except subprocess.CalledProcessError as ex:
         error = result.stdout if error_in_stdout else result.stderr
         raise IpaRunError(error) from ex
@@ -94,13 +95,13 @@ def _record_command():
 # Wrapper around `ipa_run` for find commands, to always get all fields and
 # records, not record when we run the find command, and return the parsed
 # result.
-def ipa_find(ipa_find_command, additional_args=[]):
+def ipa_find(ipa_find_command, additional_args=[], error_allowed=None):
     standard_args = [
         '--all',
         # Effectively make find command show all data.
-        '--sizelimit', '1000000'
+        '--sizelimit', '10000000'
     ]
     args = additional_args + standard_args
 
-    ipa_result = ipa_run(ipa_find_command, args, record=False)
+    ipa_result = ipa_run(ipa_find_command, args, error_allowed, record=False)
     return parse_find_output(ipa_result)

--- a/directory/cli/src/list_command.py
+++ b/directory/cli/src/list_command.py
@@ -63,7 +63,7 @@ def do(
         ipa_find_args=[],
         field_configs=None,
         sort_key=None,
-        generate_additional_data=lambda: {},
+        generate_additional_data=lambda item_dict=None: {},
         display=table_displayer,
         blacklist_key=None,
         blacklist_val_array=[]
@@ -89,7 +89,7 @@ def do(
         results_data = _create_data(
             item_dicts,
             field_configs,
-            generate_additional_data()
+            generate_additional_data(item_dict=item_dicts[0])
         )
         display(headers, results_data)
     else:

--- a/directory/cli/src/user.py
+++ b/directory/cli/src/user.py
@@ -63,7 +63,7 @@ def add_commands(directory):
                 ipa_find_command='user-find',
                 ipa_find_args=user_find_args,
                 field_configs=USER_SHOW_FIELD_CONFIGS,
-                generate_additional_data=_additional_data_for_list,
+                generate_additional_data=_additional_data_for_show,
                 display=list_command.list_displayer
             )
         except IpaRunError:
@@ -103,8 +103,8 @@ def add_commands(directory):
     for command in wrapper_commands:
         user.add_command(command)
 
-
-def _additional_data_for_list():
+def _additional_data_for_list(item_dict=None):
+    del item_dict
     return {
         'groups': _groups_by_gid()
     }
@@ -122,7 +122,6 @@ def _groups_by_gid():
             continue
     return groups_by_gid
 
-
 def _all_groups():
     # Want to get all groups, normal/public and private; I would have thought
     # there would be a single `ipa` command that would give these but AFAICT it
@@ -131,6 +130,25 @@ def _all_groups():
     private_groups = ipa_utils.ipa_find('group-find', ['--private'])
     return public_groups + private_groups
 
+# split the additional data functions for list & show to save time
+# only returns 1 private group, for the GID of the specified user
+def _additional_data_for_show(item_dict):
+    gid = item_dict['GID'][0]
+    return {
+        'groups': {
+            gid : _users_primary_group(gid)[0]
+        }
+    }
+
+def _users_primary_group(gid):
+    group_find_args = ['--gid={}'.format(gid)]
+    # will only find max one group between the two calls
+    # if the first doesn't find the group it will error but continue due to `error_allowed`
+    # if neither find it (i.e. if the GID is invalid) [{}] will be returned
+    primary_group = ipa_utils.ipa_find('group-find', group_find_args + ['--private'], error_allowed='0 groups matched')
+    if primary_group == [{}]:
+        primary_group = ipa_utils.ipa_find('group-find', group_find_args, error_allowed='0 groups matched')
+    return primary_group
 
 def _user_options(require_names=True):
     return {


### PR DESCRIPTION
- Added seperated `get additional data` method in user,
`additional_data_for_show` which instead queries ipa for a single user's
primary group rather than every users
- the call to `get additional data` now passes an item_dict which must
be ignored for other varients
- Added error ignoring functionality to `ipa_run` in `ipa_find` to
prevent silent erroring when a call returns no results
- Took time down from around 23 to 3 seconds on my environment with 2000
users and many users in groups
- Fixes #48