### PR TITLE
Ensure environment variable has a value

### DIFF
--- a/directory/cli/src/utils.py
+++ b/directory/cli/src/utils.py
@@ -109,4 +109,4 @@ def display_success():
     click.echo("------------- " + command_string + " successful -------------")
 
 def advanced_mode_enabled():
-    return getenv('ADVANCED').lower() == 'true'
+    return getenv('ADVANCED', default='false').lower() == 'true'


### PR DESCRIPTION
After the changes made at the end of #70 I neglected to test and resolve the fact that initially the environment variable being checked is set to `None`. This means that when the program attempts to call `.lower()` on it an error is returned preventing the sandbox from executing correctly. 

This PR ensures the environment variable has a default value for this sort of situation.