### PR TITLE
Consistent primary group assignment

### DIFF
--- a/directory/cli/src/test_import_export.py
+++ b/directory/cli/src/test_import_export.py
@@ -18,6 +18,7 @@ def test_import_runs_directory_cli_with_each_line(
         mocker
 ):
     mocker.spy(utils, 'directory_run')
+    test_utils.mock_ipa_find_output(mocker)
 
     test_record = tmpdir.mkdir('somedir').join('record').strpath
     with open(test_record, 'w') as record_file:
@@ -45,6 +46,7 @@ def test_import_outputs_last_password_generated_for_each_user(
     mocker.spy(utils, 'directory_run')
 
     _mock_ipa_run_output(monkeypatch)
+    test_utils.mock_ipa_find_output(mocker)
 
     # TODO this tests a lot of related things; could be worth breaking up into
     # more discrete tests.
@@ -95,7 +97,7 @@ def _mock_ipa_run_output(monkeypatch):
 
         mock_output_lines = [
             'Junk: junk entry',
-            'User login: {}'.format(user_login),
+            'User login: {}'.format(user_login)
         ]
         if '--random' in ipa_args:
             # Assume that if `--random` arg is passed, the IPA command will

--- a/directory/cli/src/test_import_export.py
+++ b/directory/cli/src/test_import_export.py
@@ -89,15 +89,15 @@ def test_import_outputs_last_password_generated_for_each_user(
 
 
 def _mock_ipa_run_output(monkeypatch):
-    def mock_ipa_run(ipa_command, args, **kwargs):
-        user_login = args[0]
+    def mock_ipa_run(ipa_command, ipa_args, *_args, **_kwargs):
+        user_login = ipa_args[0]
         mock_password = '{}_{}_password'.format(user_login, ipa_command)
 
         mock_output_lines = [
             'Junk: junk entry',
             'User login: {}'.format(user_login),
         ]
-        if '--random' in args:
+        if '--random' in ipa_args:
             # Assume that if `--random` arg is passed, the IPA command will
             # successfully output a random password.
             mock_output_lines.append(

--- a/directory/cli/src/test_user_advanced.py
+++ b/directory/cli/src/test_user_advanced.py
@@ -5,15 +5,13 @@ import directory
 import ipa_utils
 import test_utils
 import appliance_cli.utils
-from appliance_cli.testing_utils import click_run
-
 
 # This setup runs before every test ensuring that they are run in advanced mode
 def setUpModule():
     test_utils.reload_in_advanced_mode()
 
 def test_user_create_includes_random_by_default(mocker):
-    _test_options_passed_to_ipa(
+    test_utils.mock_options_passed_to_ipa(
         mocker,
         ['user', 'create', 'barney', '--first', 'Barney', '--last', 'Rubble'],
         [
@@ -39,7 +37,7 @@ def test_user_create_includes_random_by_default(mocker):
 
 
 def test_user_create_does_not_pass_random_when_given_no_password(mocker):
-    _test_options_passed_to_ipa(
+    test_utils.mock_options_passed_to_ipa(
         mocker,
         ['user', 'create', 'barney', '--first', 'Barney',
             '--last', 'Rubble', '--no-password'],
@@ -66,7 +64,7 @@ def test_user_create_does_not_pass_random_when_given_no_password(mocker):
 
 
 def test_user_create_passes_sshpubkey_when_given_key(mocker):
-    _test_options_passed_to_ipa(
+    test_utils.mock_options_passed_to_ipa(
         mocker,
         ['user', 'create', 'barney', '--first', 'Barney', '--last', 'Rubble',
             '--key', 'ssh-rsa somekey key_name'],
@@ -97,7 +95,7 @@ def test_user_create_passes_sshpubkey_when_given_key(mocker):
 # given single name. Will need to mock `ipa_find` for user.
 
 def test_user_modify_includes_nothing_extra_by_default(mocker):
-    _test_options_passed_to_ipa(
+    test_utils.mock_options_passed_to_ipa(
         mocker,
         ['user', 'modify', 'barney'],
         [
@@ -112,7 +110,7 @@ def test_user_modify_includes_nothing_extra_by_default(mocker):
 
 
 def test_user_modify_includes_extra_names_when_given_names(mocker):
-    _test_options_passed_to_ipa(
+    test_utils.mock_options_passed_to_ipa(
         mocker,
         ['user', 'modify', 'barney', '--first', 'Barney', '--last', 'Rubble'],
         [
@@ -128,7 +126,7 @@ def test_user_modify_includes_extra_names_when_given_names(mocker):
 
 
 def test_user_modify_passes_random_when_given_new_password(mocker):
-    _test_options_passed_to_ipa(
+   test_utils.mock_options_passed_to_ipa(
         mocker,
         ['user', 'modify', 'barney', '--new-password'],
         [
@@ -143,7 +141,7 @@ def test_user_modify_passes_random_when_given_new_password(mocker):
 
 
 def test_user_modify_passes_sshpubkey_when_given_key(mocker):
-    _test_options_passed_to_ipa(
+    test_utils.mock_options_passed_to_ipa(
         mocker,
         ['user', 'modify', 'barney', '--key', 'ssh-rsa somekey key_name'],
         [
@@ -158,7 +156,7 @@ def test_user_modify_passes_sshpubkey_when_given_key(mocker):
 
 
 def test_user_modify_passes_empty_sshpubkey_when_given_remove_key(mocker):
-    _test_options_passed_to_ipa(
+   test_utils.mock_options_passed_to_ipa(
         mocker,
         ['user', 'modify', 'barney', '--remove-key'],
         [
@@ -180,7 +178,7 @@ def test_user_modify_passes_random_password_when_given_remove_password(
         appliance_cli.utils, 'secure_random_string', lambda: mock_password
     )
 
-    _test_options_passed_to_ipa(
+    test_utils.mock_options_passed_to_ipa(
         mocker,
         ['user', 'modify', 'barney', '--remove-password'],
         [
@@ -193,21 +191,3 @@ def test_user_modify_passes_random_password_when_given_remove_password(
         ]
     )
 
-
-def _test_options_passed_to_ipa(mocker, directory_command, ipa_run_arguments):
-    mocker.spy(ipa_utils, 'ipa_run')
-
-    click_run(directory.directory, directory_command)
-
-    expected_ipa_calls = [mock_call(command_with_args) for command_with_args in ipa_run_arguments]
-    assert ipa_utils.ipa_run.call_args_list == expected_ipa_calls
-
-def mock_call(command_with_args):
-    command, args, *rest = command_with_args
-
-    try:
-        kwargs = rest[0]
-    except IndexError:
-        kwargs = {}
-
-    return mock.call(command, *args, **kwargs)

--- a/directory/cli/src/test_user_advanced.py
+++ b/directory/cli/src/test_user_advanced.py
@@ -11,25 +11,21 @@ def setUpModule():
     test_utils.reload_in_advanced_mode()
 
 def test_user_create_includes_random_by_default(mocker):
+    test_utils.mock_ipa_find_output(mocker)
     test_utils.mock_options_passed_to_ipa(
         mocker,
         ['user', 'create', 'barney', '--first', 'Barney', '--last', 'Rubble'],
         [
             (
-                'group-find',
-                [
-                    [
-                        'clusterusers',
-                        '--sizelimit', '0'
-                    ],
-                    None
-                ],
-              { 'record': False }
-            ),
-            (
                 'user-add',
                 [
-                    ['barney', '--first', 'Barney', '--last', 'Rubble', '--random']
+                    [
+                        'barney',
+                        '--first',  'Barney',
+                        '--gidnumber', 'clusterusers_gid',
+                        '--last', 'Rubble',
+                        '--random'
+                    ]
                 ]
             )
         ],
@@ -37,26 +33,21 @@ def test_user_create_includes_random_by_default(mocker):
 
 
 def test_user_create_does_not_pass_random_when_given_no_password(mocker):
+    test_utils.mock_ipa_find_output(mocker)
     test_utils.mock_options_passed_to_ipa(
         mocker,
         ['user', 'create', 'barney', '--first', 'Barney',
             '--last', 'Rubble', '--no-password'],
         [
             (
-                'group-find',
-                [
-                    [
-                        'clusterusers',
-                        '--sizelimit', '0'
-                    ],
-                    None
-                ],
-              { 'record': False }
-            ),
-            (
                 'user-add',
                 [
-                    ['barney', '--first', 'Barney', '--last', 'Rubble']
+                    [
+                        'barney',
+                        '--first', 'Barney',
+                        '--gidnumber', 'clusterusers_gid',
+                        '--last', 'Rubble'
+                    ]
                 ]
             )
         ]
@@ -64,27 +55,23 @@ def test_user_create_does_not_pass_random_when_given_no_password(mocker):
 
 
 def test_user_create_passes_sshpubkey_when_given_key(mocker):
+    test_utils.mock_ipa_find_output(mocker)
     test_utils.mock_options_passed_to_ipa(
         mocker,
         ['user', 'create', 'barney', '--first', 'Barney', '--last', 'Rubble',
             '--key', 'ssh-rsa somekey key_name'],
         [
             (
-                'group-find',
-                [
-                    [
-                        'clusterusers',
-                        '--sizelimit', '0'
-                    ],
-                    None
-                ],
-              { 'record': False }
-            ),
-            (
                 'user-add',
                 [
-                    ['barney', '--first', 'Barney', '--last', 'Rubble', '--random',
-                '--sshpubkey', 'ssh-rsa somekey key_name']
+                    [
+                        'barney',
+                        '--first', 'Barney',
+                        '--gidnumber', 'clusterusers_gid',
+                        '--last', 'Rubble',
+                        '--random',
+                        '--sshpubkey', 'ssh-rsa somekey key_name'
+                    ]
                 ]
             )
         ]

--- a/directory/cli/src/test_user_simple.py
+++ b/directory/cli/src/test_user_simple.py
@@ -12,21 +12,11 @@ def setUpModule():
     test_utils.reload_in_simple_mode()
 
 def test_user_create_calls_ipa_correctly(mocker):
+    test_utils.mock_ipa_find_output(mocker)
     test_utils.mock_options_passed_to_ipa(
         mocker,
         ['user', 'create'],
         [
-            (
-                'group-find',
-                [
-                    [
-                        'clusterusers',
-                        '--sizelimit', '0'
-                    ],
-                    None
-                ],
-                { 'record': False }
-            ),
             (
                 'user-add',
                 [
@@ -34,6 +24,7 @@ def test_user_create_calls_ipa_correctly(mocker):
                         'walterwhite',
                         '--email', 'heisenberg@example.com',
                         '--first', 'Walter',
+                        '--gidnumber', 'clusterusers_gid',
                         '--last', 'White',
                         '--random'
                     ]
@@ -44,22 +35,11 @@ def test_user_create_calls_ipa_correctly(mocker):
     )
 
 def test_user_modify_calls_ipa_correctly(mocker):
+    test_utils.mock_ipa_find_output(mocker)
     test_utils.mock_options_passed_to_ipa(
         mocker,
         ['user', 'modify'],
         [
-            (
-                'user-find',
-                [
-                    [
-                        '--login=walterwhite',
-                        '--all',
-                        '--sizelimit', '0'
-                    ],
-                    None
-                ],
-                { 'record': False }
-            ),
             (
                 'user-mod',
                 [

--- a/directory/cli/src/test_user_simple.py
+++ b/directory/cli/src/test_user_simple.py
@@ -58,7 +58,7 @@ def test_user_create_without_uid_calls_ipa_correctly(mocker):
         'walterwhite\nWalter\nWhite\nheisenberg@example.com\nNo\n',
     )
 
-def test_user_modify_calls_ipa_correctly(mocker):
+def test_user_modify_with_modifications_calls_ipa_correctly(mocker):
     test_utils.mock_ipa_find_output(mocker)
     test_utils.mock_options_passed_to_ipa(
         mocker,
@@ -79,5 +79,30 @@ def test_user_modify_calls_ipa_correctly(mocker):
             )
         ],
         'walterwhite\nWalt\nJackson\nnotheisenberg@example.com\nNo\n',
+    )
+
+# We would expect this test to match the defaults mocked within
+# mock_ipa_find_output
+def test_user_modify_without_modifications_calls_ipa_correctly(mocker):
+    test_utils.mock_ipa_find_output(mocker)
+    test_utils.mock_options_passed_to_ipa(
+        mocker,
+        ['user', 'modify'],
+        [
+            (
+                'user-mod',
+                [
+                    [
+                        'walterwhite',
+                        '--cn', 'walterwhite_first walterwhite_last',
+                        '--displayname', 'walterwhite_first walterwhite_last',
+                        '--email', 'walterwhite_email',
+                        '--first', 'walterwhite_first',
+                        '--last', 'walterwhite_last'
+                    ]
+                ]
+            )
+        ],
+        'walterwhite\n\n\n\n\n'
     )
 

--- a/directory/cli/src/test_user_simple.py
+++ b/directory/cli/src/test_user_simple.py
@@ -11,7 +11,31 @@ from click.testing import CliRunner
 def setUpModule():
     test_utils.reload_in_simple_mode()
 
-def test_user_create_calls_ipa_correctly(mocker):
+def test_user_create_with_uid_calls_ipa_correctly(mocker):
+    test_utils.mock_ipa_find_output(mocker)
+    test_utils.mock_options_passed_to_ipa(
+        mocker,
+        ['user', 'create'],
+        [
+            (
+                'user-add',
+                [
+                    [
+                        'walterwhite',
+                        '--email', 'heisenberg@example.com',
+                        '--first', 'Walter',
+                        '--gidnumber', 'clusterusers_gid',
+                        '--last', 'White',
+                        '--random',
+                        '--uid', '9001'
+                    ]
+                ]
+            )
+        ],
+        'walterwhite\nWalter\nWhite\nheisenberg@example.com\nYes\n9001\n',
+    )
+
+def test_user_create_without_uid_calls_ipa_correctly(mocker):
     test_utils.mock_ipa_find_output(mocker)
     test_utils.mock_options_passed_to_ipa(
         mocker,

--- a/directory/cli/src/test_user_simple.py
+++ b/directory/cli/src/test_user_simple.py
@@ -4,8 +4,6 @@ from unittest import mock
 import directory
 import ipa_utils
 import test_utils
-import appliance_cli.utils
-from appliance_cli.testing_utils import click_run
 
 from click.testing import CliRunner
 
@@ -14,10 +12,9 @@ def setUpModule():
     test_utils.reload_in_simple_mode()
 
 def test_user_create_calls_ipa_correctly(mocker):
-    _test_options_passed_to_ipa(
+    test_utils.mock_options_passed_to_ipa(
         mocker,
         ['user', 'create'],
-        'walterwhite\nWalter\nWhite\nheisenberg@example.com\nNo\n',
         [
             (
                 'group-find',
@@ -42,14 +39,14 @@ def test_user_create_calls_ipa_correctly(mocker):
                     ]
                 ]
             )
-        ]
+        ],
+        'walterwhite\nWalter\nWhite\nheisenberg@example.com\nNo\n',
     )
 
 def test_user_modify_calls_ipa_correctly(mocker):
-    _test_options_passed_to_ipa(
+    test_utils.mock_options_passed_to_ipa(
         mocker,
         ['user', 'modify'],
-        'walterwhite\nWalt\nJackson\nnotheisenberg@example.com\nNo\n',
         [
             (
                 'user-find',
@@ -76,23 +73,7 @@ def test_user_modify_calls_ipa_correctly(mocker):
                     ]
                 ]
             )
-        ]
+        ],
+        'walterwhite\nWalt\nJackson\nnotheisenberg@example.com\nNo\n',
     )
 
-def _test_options_passed_to_ipa(mocker, directory_command, input_stream, ipa_run_arguments):
-    mocker.spy(ipa_utils, 'ipa_run')
-
-    click_run(directory.directory, directory_command, input=input_stream)
-
-    expected_ipa_calls = [mock_call(command_with_args) for command_with_args in ipa_run_arguments]
-    assert ipa_utils.ipa_run.call_args_list == expected_ipa_calls
-
-def mock_call(command_with_args):
-    command, args, *rest = command_with_args
-
-    try:
-        kwargs = rest[0]
-    except IndexError:
-        kwargs = {}
-
-    return mock.call(command, *args, **kwargs)

--- a/directory/cli/src/test_utils.py
+++ b/directory/cli/src/test_utils.py
@@ -27,7 +27,9 @@ def mock_options_passed_to_ipa(mocker, directory_command, ipa_run_arguments, inp
     assert ipa_utils.ipa_run.call_args_list == expected_ipa_calls
 
 def mock_ipa_find_output(mocker):
+    # Mocks ipa_utils.ipa_find for the command given
     def mock_ipa_find(ipa_command, ipa_args, *args, **kwargs):
+        # Tests that expect to call group-find grab the mocked GID here
         if ipa_command == 'group-find':
             group_name = ipa_args[0]
             return  [
@@ -35,10 +37,16 @@ def mock_ipa_find_output(mocker):
                             'GID': ['{}_gid'.format(group_name)]
                         }
                     ]
+
+        # Tests that need user data found via calling user-find go here
         elif ipa_command == 'user-find':
+            # If the test searches via UID for an existing user we return
+            # none to mock that the user is new
             if '--uid' in ipa_args[0]:
                 return None
 
+            # Mock data is returned to tests that call user-find and require
+            # values that aren't empty
             username = ipa_args[0].replace('--login=', '')
             return  [
                         {

--- a/directory/cli/src/test_utils.py
+++ b/directory/cli/src/test_utils.py
@@ -11,14 +11,10 @@ from unittest import mock
 from appliance_cli.testing_utils import click_run
 
 def reload_in_advanced_mode():
-    execute_reload('true')
+    _execute_reload('true')
 
 def reload_in_simple_mode():
-    execute_reload('false')
-
-def execute_reload(val):
-    os.environ['ADVANCED'] = val
-    importlib.reload(directory)
+    _execute_reload('false')
 
 def mock_options_passed_to_ipa(mocker, directory_command, ipa_run_arguments, input_stream=None):
     mocker.spy(ipa_utils, 'ipa_run')
@@ -29,6 +25,10 @@ def mock_options_passed_to_ipa(mocker, directory_command, ipa_run_arguments, inp
         _mock_call(command_with_args) for command_with_args in ipa_run_arguments
     ]
     assert ipa_utils.ipa_run.call_args_list == expected_ipa_calls
+
+def _execute_reload(val):
+    os.environ['ADVANCED'] = val
+    importlib.reload(directory)
 
 def _mock_call(command_with_args):
     command, args, *rest = command_with_args

--- a/directory/cli/src/test_utils.py
+++ b/directory/cli/src/test_utils.py
@@ -36,6 +36,9 @@ def mock_ipa_find_output(mocker):
                         }
                     ]
         elif ipa_command == 'user-find':
+            if '--uid' in ipa_args[0]:
+                return None
+
             username = ipa_args[0].replace('--login=', '')
             return  [
                         {

--- a/directory/cli/src/test_utils.py
+++ b/directory/cli/src/test_utils.py
@@ -26,6 +26,27 @@ def mock_options_passed_to_ipa(mocker, directory_command, ipa_run_arguments, inp
     ]
     assert ipa_utils.ipa_run.call_args_list == expected_ipa_calls
 
+def mock_ipa_find_output(mocker):
+    def mock_ipa_find(ipa_command, ipa_args, *args, **kwargs):
+        if ipa_command == 'group-find':
+            group_name = ipa_args[0]
+            return  [
+                        {
+                            'GID': ['{}_gid'.format(group_name)]
+                        }
+                    ]
+        elif ipa_command == 'user-find':
+            username = ipa_args[0].replace('--login=', '')
+            return  [
+                        {
+                            'First name': ['{}_first'.format(username)],
+                            'Last name': ['{}_last'.format(username)],
+                            'Email address': ['{}_email'.format(username)]
+                        }
+                    ]
+
+    mocker.patch('ipa_utils.ipa_find', mock_ipa_find)
+
 def _reload_with_advanced_set_to(val):
     os.environ['ADVANCED'] = val
     importlib.reload(directory)

--- a/directory/cli/src/test_utils.py
+++ b/directory/cli/src/test_utils.py
@@ -1,9 +1,14 @@
 
 # This file contains utils for testing rather than tests designed for utils.py
 
-import directory
 import os
 import importlib
+import ipa_utils
+import directory
+import appliance_cli.utils
+
+from unittest import mock
+from appliance_cli.testing_utils import click_run
 
 def reload_in_advanced_mode():
     execute_reload('true')
@@ -15,3 +20,22 @@ def execute_reload(val):
     os.environ['ADVANCED'] = val
     importlib.reload(directory)
 
+def mock_options_passed_to_ipa(mocker, directory_command, ipa_run_arguments, input_stream=None):
+    mocker.spy(ipa_utils, 'ipa_run')
+
+    click_run(directory.directory, directory_command, input=input_stream)
+
+    expected_ipa_calls = [
+        _mock_call(command_with_args) for command_with_args in ipa_run_arguments
+    ]
+    assert ipa_utils.ipa_run.call_args_list == expected_ipa_calls
+
+def _mock_call(command_with_args):
+    command, args, *rest = command_with_args
+
+    try:
+        kwargs = rest[0]
+    except IndexError:
+        kwargs = {}
+
+    return mock.call(command, *args, **kwargs)

--- a/directory/cli/src/test_utils.py
+++ b/directory/cli/src/test_utils.py
@@ -11,10 +11,10 @@ from unittest import mock
 from appliance_cli.testing_utils import click_run
 
 def reload_in_advanced_mode():
-    _execute_reload('true')
+    _reload_with_advanced_set_to('true')
 
 def reload_in_simple_mode():
-    _execute_reload('false')
+    _reload_with_advanced_set_to('false')
 
 def mock_options_passed_to_ipa(mocker, directory_command, ipa_run_arguments, input_stream=None):
     mocker.spy(ipa_utils, 'ipa_run')
@@ -26,7 +26,7 @@ def mock_options_passed_to_ipa(mocker, directory_command, ipa_run_arguments, inp
     ]
     assert ipa_utils.ipa_run.call_args_list == expected_ipa_calls
 
-def _execute_reload(val):
+def _reload_with_advanced_set_to(val):
     os.environ['ADVANCED'] = val
     importlib.reload(directory)
 

--- a/directory/cli/src/user.py
+++ b/directory/cli/src/user.py
@@ -120,15 +120,15 @@ def add_commands(directory):
                 'login': user,
                 'first': click.prompt(
                     '  First name',
-                    default=user_data.get('First name', 'empty')[0]
+                    default=user_data['First name'][0]
                 ),
                 'last': click.prompt(
                     '  Surname',
-                    default=user_data.get('Last name', 'empty')[0]
+                    default=user_data['Last name'][0]
                 ),
                 'email': click.prompt(
                     '  Email',
-                    default=user_data.get('Email address', 'empty')[0]
+                    default=user_data['Email address'][0]
                 )
             }
 
@@ -302,8 +302,7 @@ def _transform_create_options(argument, options):
     else:
         group_id = _get_group_id('clusterusers')
 
-        if group_id:
-            options['gidnumber'] = group_id[0]
+        options['gidnumber'] = group_id
     if utils.get_password_policy():
         return OptionTransformer(argument, options).\
             rename_flag_option('make_password', 'random').\
@@ -483,7 +482,7 @@ def _get_group_id(group):
             'group-find',
             [group],
             all_fields=False
-        )[0].get('GID')
+        )[0].get('GID')[0]
     except IpaRunError:
         error = '{}: group not found'.format(group)
         raise click.ClickException(error)

--- a/directory/cli/src/user.py
+++ b/directory/cli/src/user.py
@@ -90,11 +90,6 @@ def add_commands(directory):
             ):
                 params = { **params, 'uid': click.prompt('  UID') }
 
-            group_id = _get_group_id('clusterusers')
-
-            if group_id:
-                params = { **params, 'gidnumber': group_id[0] }
-
             wrapper = ipa_wrapper_command.create_ipa_wrapper(
                 'user-add',
                 argument_name='login',
@@ -302,8 +297,13 @@ def _transform_options(argument, options):
 def _transform_create_options(argument, options):
     _validate_blacklist_users(argument)
     _validate_create_uid(options['uid'])
-    if options['gidnumber'] == None and utils.detect_user_config():
+    if utils.detect_user_config():
         options['gidnumber'] = utils.get_user_config('DEFAULT_GID')
+    else:
+        group_id = _get_group_id('clusterusers')
+
+        if group_id:
+            options['gidnumber'] = group_id[0]
     if utils.get_password_policy():
         return OptionTransformer(argument, options).\
             rename_flag_option('make_password', 'random').\

--- a/directory/cli/src/user.py
+++ b/directory/cli/src/user.py
@@ -115,7 +115,10 @@ def add_commands(directory):
                 error = '{}: user not found'.format(user)
                 raise click.ClickException(error)
 
-            click.echo('Modifying user (%s)' % user)
+            click.echo(
+                'Adjust the following fields as necessary:\n'
+                'Leave blank to keep current value shown within brackets'
+            )
             params = {
                 'login': user,
                 'first': click.prompt(

--- a/directory/cli/src/user.py
+++ b/directory/cli/src/user.py
@@ -252,7 +252,6 @@ def _user_options(require_names=True):
         '--shell': {'help': 'Login shell'},
         '--email': {'help': 'Email address'},
         '--uid': {'help': 'User ID Number'},
-        '--gidnumber': {'help': 'Group ID Number'},
         '--key': {'help': 'SSH public key'},
         '--homedir': {'help': 'Home directory'},
         '--gecos': {'help': 'GECOS field'},


### PR DESCRIPTION
Based on #72 this PR implements consistency in how primary group assignment works between simple and advanced mode. In both modes it will now first attempt to assign the `GID` to the value of `DEFAULT_GID` within the config. If this value does not exist it then looks for the `clusterusers` group and assigns accordingly. However if both of these are unavailable IPA should assign the primary group to its own default.

### Group precedence
Config `DEFAULT_GID` value > `clusterusers` group > IPA default

### Notes

This PR also contains various changes related to #72. Once that branch has been merged this one will need to be rebased. Until then this PR can be ignored.