### PR TITLE
Refactor primary group assignment

### DIFF
--- a/directory/cli/src/user.py
+++ b/directory/cli/src/user.py
@@ -480,13 +480,14 @@ def _run_post_create_script(login):
             raise IpaRunError(error) from ex
 
 def _standard_default_user_gid():
+    # If a default GID is set within the config this takes precedence.
+    # However if this value is absent or blank it will attempt to find the GID
+    # of the clusterusers group
     return utils.get_user_config('DEFAULT_GID') or _get_group_id('clusterusers')
 
 def _get_group_id(group):
-    # These comments will be moved/replaced if this ends up working
-    # If a default GID is set within the config this takes precedence
         # If there is no config value set it attempts to set the GID to
-        # the 'clusterusers' group
+        # the clusterusers group
         try:
             return ipa_utils.ipa_find(
                 'group-find',

--- a/directory/cli/src/user.py
+++ b/directory/cli/src/user.py
@@ -486,14 +486,14 @@ def _standard_default_user_gid():
     return utils.get_user_config('DEFAULT_GID') or _get_group_id('clusterusers')
 
 def _get_group_id(group):
-        # If there is no config value set it attempts to set the GID to
-        # the clusterusers group
-        try:
-            return ipa_utils.ipa_find(
-                'group-find',
-                [group],
-                all_fields=False
-            )[0].get('GID')[0]
-        except IpaRunError:
-            error = '{}: group not found'.format(group)
-            raise click.ClickException(error)
+    # If there is no config value set it attempts to set the GID to
+    # the clusterusers group
+    try:
+        return ipa_utils.ipa_find(
+            'group-find',
+            [group],
+            all_fields=False
+        )[0].get('GID')[0]
+    except IpaRunError:
+        error = '{}: group not found'.format(group)
+        raise click.ClickException(error)

--- a/directory/cli/src/user.py
+++ b/directory/cli/src/user.py
@@ -480,6 +480,9 @@ def _run_post_create_script(login):
             error = script_result.stdout if error_in_stdout else script_result.stderr
             raise IpaRunError(error) from ex
 
+def _standard_default_user_gid():
+    return utils.get_user_config('DEFAULT_GID') or _get_group_id('clusterusers')
+
 def _get_group_id(group):
     # If a default GID is set within the config this takes precedence
     if utils.detect_user_config():

--- a/directory/cli/src/user.py
+++ b/directory/cli/src/user.py
@@ -495,5 +495,4 @@ def _get_group_id(group):
             all_fields=False
         )[0].get('GID')[0]
     except IpaRunError:
-        error = '{}: group not found'.format(group)
-        raise click.ClickException(error)
+        return None

--- a/directory/cli/src/user.py
+++ b/directory/cli/src/user.py
@@ -486,8 +486,9 @@ def _standard_default_user_gid():
     return utils.get_user_config('DEFAULT_GID') or _get_group_id('clusterusers')
 
 def _get_group_id(group):
-    # If there is no config value set it attempts to set the GID to
-    # the clusterusers group
+    # If present the clusterusers group now takes precedence.
+    # However as a last resort this will return None. This causes IPA to use
+    # its default.
     try:
         return ipa_utils.ipa_find(
             'group-find',
@@ -495,4 +496,7 @@ def _get_group_id(group):
             all_fields=False
         )[0].get('GID')[0]
     except IpaRunError:
+        # It might be worth adjusting this so that it only returns None when
+        # the group can't be found. Currently this will catch all IPA run
+        # errors which isn't ideal.
         return None

--- a/directory/cli/src/user.py
+++ b/directory/cli/src/user.py
@@ -304,8 +304,7 @@ def _transform_create_options(argument, options):
     _validate_blacklist_users(argument)
     _validate_create_uid(options['uid'])
 
-    group_id = _get_group_id('clusterusers')
-    options['gidnumber'] = group_id
+    options['gidnumber'] = _standard_default_user_gid()
 
     if utils.get_password_policy():
         return OptionTransformer(argument, options).\
@@ -484,10 +483,8 @@ def _standard_default_user_gid():
     return utils.get_user_config('DEFAULT_GID') or _get_group_id('clusterusers')
 
 def _get_group_id(group):
+    # These comments will be moved/replaced if this ends up working
     # If a default GID is set within the config this takes precedence
-    if utils.detect_user_config():
-        return utils.get_user_config('DEFAULT_GID')
-    else:
         # If there is no config value set it attempts to set the GID to
         # the 'clusterusers' group
         try:


### PR DESCRIPTION
Addresses https://github.com/alces-software/userware/pull/73/files/479471c3237ee4e166125b7609d029d4bd92bd63#r239890927. GID assignment should now follow the precedence stated within #73 and hopefully be a bit cleaner.