### PR TITLE
Stop prompt-mode user modify requiring an ssh key

### DIFF
--- a/directory/cli/src/user.py
+++ b/directory/cli/src/user.py
@@ -186,12 +186,6 @@ Please enter the name of the user you want to modify:
                     'Leave blank to keep current value shown within brackets'
                 )
 
-                ssh_key_list = user_data.get('SSH public key')
-                if ssh_key_list:
-                    ssh_key_default = ssh_key_list[0]
-                else:
-                    ssh_key_default = 'None'
-
                 params = OrderedDict([
                     ('login', user),
                     ('first', click.prompt(
@@ -206,11 +200,12 @@ Please enter the name of the user you want to modify:
                         '  Email',
                         default=user_data['Email address'][0]
                     )),
-                    ('key', click.prompt(
-                        '  SSH public key',
-                        default=ssh_key_default
-                    ))
                 ])
+                ssh_key_list = user_data.get('SSH public key')
+                ssh_key_default = ssh_key_list[0] if ssh_key_list else 'None'
+                new_ssh = click.prompt('  SSH public key', default=ssh_key_default)
+                if new_ssh != 'None':
+                    params = { **params, 'key': new_ssh }
 
             wrapper(**params)
 


### PR DESCRIPTION
Previously if in simple mode & modifying a user via the prompts system,
if the user did not have an ssh key set & a new value wasn't
passed the system would try to pass "None" (as a string) as its value.
This would necessarily produce an "ipa: ERROR: invalid 'sshpubkey':
invalid SSH public key" error as 'None' is not a valid ssh_key.

This system has now been changed to only pass the value if it's not the
default.