### PR TITLE
Fix crash on 'find' output having multiple colons

### DIFF
--- a/directory/cli/src/ipa_utils.py
+++ b/directory/cli/src/ipa_utils.py
@@ -52,7 +52,7 @@ def _info_section_boundary(line):
 
 
 def _process_delimited_find_output_line(line):
-    key, raw_value = _strip_all(line.split(FIND_OUTPUT_DELIMITER))
+    key, raw_value = _strip_all(line.split(FIND_OUTPUT_DELIMITER, 1))
 
     if key in RAW_FIELD_WHITELIST:
         # Wrap in list for consistency with other values.


### PR DESCRIPTION
previously it crashed out as it would attempt to assign a length >2
array to two variables, now cannot produce an array of greater length than 2