### PR TITLE
Run IPA commands through new wrapper script

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,10 @@ Currently this repository is just a collection of the code from [Imageware](http
 
 Note: This does not setup an IPA server, that must be done separately. For more information on setting up an IPA server see the [Cluster Platform Knowledgebase instructions](http://cluster-platform-knowledgebase.readthedocs.io/en/latest/user-management/user-management-guidelines.html#ipa-server-setup)
 
+- Install dependencies
+
+`yum install apg` (Required for `password-generator` script)
+
 - Clone the repository
 
 ```

--- a/README.md
+++ b/README.md
@@ -23,7 +23,10 @@ Note: This does not setup an IPA server, that must be done separately. For more 
 
 - Install dependencies
 
-`yum install apg` (Required for `password-generator` script)
+```
+yum install apg
+``` 
+(Required for `password-generator` script)
 
 - Clone the repository
 

--- a/directory/cli/src/config.py
+++ b/directory/cli/src/config.py
@@ -55,6 +55,7 @@ _DIRECTORY_CONFIG = {
         'command-line access via SSH and full access to FreeIPA.'
     ),
     'SUPPORT_EJECT_SUCCESS_MESSAGE_CALLBACK': _support_eject_success_message,
+    'IPA_WRAPPER_SCRIPT_PATH': join(_STANDARD_CONFIG['APPLIANCE_DIR'], 'libexec/userware-ipa-wrapper')
 }
 
 CONFIG = appliance_cli.config.finalize_config(

--- a/directory/cli/src/ipa_utils.py
+++ b/directory/cli/src/ipa_utils.py
@@ -70,7 +70,7 @@ def _strip_all(strings):
 
 
 def ipa_run(ipa_command, args=[], error_allowed=None, error_in_stdout=False, record=True):
-    command = ['ipa', '--no-prompt'] + [ipa_command] + args
+    command = [CONFIG.IPA_WRAPPER_SCRIPT_PATH] + [ipa_command] + args
 
     try:
         result = appliance_cli.utils.run(command)

--- a/directory/cli/src/user.py
+++ b/directory/cli/src/user.py
@@ -328,6 +328,9 @@ def _create_options():
     if utils.get_password_policy():
         return {
             **_user_options(),
+            '--group': {
+                'help': 'Specify a group to assign the user to on creation'
+            },
             '--make-password': {
                 'help': 'Generate a temporary password',
                 'is_flag': True,
@@ -336,6 +339,9 @@ def _create_options():
     else:
         return {
             **_user_options(),
+            '--group': {
+                'help': 'Specify a group to assign the user to on creation'
+            },
             '--no-password': {
                 'help': 'Do not generate temporary password',
                 'is_flag': True,
@@ -381,7 +387,6 @@ def _transform_create_options(argument, options):
             rename_and_invert_flag_option('no_password', 'random').\
             rename_option('key', 'sshpubkey').\
             options
-
 
 def _validate_create_uid(uid):
     if not uid:

--- a/directory/libexec/password-generator
+++ b/directory/libexec/password-generator
@@ -1,0 +1,6 @@
+#!/bin/bash
+if [ -x /usr/bin/apg ]; then
+  /usr/bin/apg -n1 -M Ncl -m 8 -x 8
+else
+  dd if=/dev/urandom bs=64 count=1 2>/dev/null | base64 -w0 | cut -c1-8 | tr '/+' 'ab'
+fi

--- a/directory/libexec/userware-ipa-wrapper
+++ b/directory/libexec/userware-ipa-wrapper
@@ -1,0 +1,55 @@
+#!/bin/bash
+dir="$(cd $(dirname "$0") && pwd)"
+cmd=$1
+case $cmd in
+    user-add)
+	if [[ "$* " == *" --group "* || "$*" == *" --random "* ]]; then
+	    uname=$2
+	    args=()
+	    for a in "$@"; do
+		if [ "$a" == "--random" ]; then
+		    if [ -x "${dir}"/password-generator ]; then
+			password="$("${dir}"/password-generator)"
+		    else
+			args+=($a)
+		    fi
+		elif [ "$a" == "--group" ]; then
+		    grab_group=true
+		elif [ "$grab_group" ]; then
+		    group="$a"
+		    unset grab_group
+		else
+		    args+=($a)
+		fi
+	    done
+	    tmpf=$(mktemp /tmp/userware-ipa-wrapper.XXXXXXX)
+	    ipa --no-prompt "${args[@]}" > $tmpf
+	    rc=$?
+	    if [ $rc == 0 -a -n "$group" ]; then
+		ipa --no-prompt group-add-member $group --users=$uname &>/dev/null
+		rc=$?
+		if [ $rc != 0 ]; then
+		    ipa user-del $uname &>/dev/null
+		fi
+	    fi
+	    if [ $rc == 0 -a -n "${password}" ]; then
+		echo "${password}" | ipa passwd $uname &>/dev/null
+		rc=$?
+		if [ $rc != 0 ]; then
+		    ipa user-del $uname &>/dev/null
+		else
+		    sed -i 's/^Password: False/Password: true/g' $tmpf
+		    echo "  Random password: ${password}" >> $tmpf
+		fi
+	    fi
+	    cat $tmpf 
+	    rm -f $tmpf
+	    exit $rc
+	else
+	    exec ipa --no-prompt "$@"
+	fi
+	;;
+    *)
+	exec ipa --no-prompt "$@"
+	;;
+esac


### PR DESCRIPTION
Thanks to @mjtko for providing the new scripts found within `libexec/` all IPA commands are run through the new wrapper script which resolves certain development issues.

With these scripts integrated into `Userware`  and a new `--group` option added to `user create` the following issues can be updated:
* Resolves #94 
* Resolves #95 